### PR TITLE
Inconsistent entity

### DIFF
--- a/src/GoalioForgotPassword/Entity/Password.php
+++ b/src/GoalioForgotPassword/Entity/Password.php
@@ -54,10 +54,4 @@ class Password
         }
         return $this->requestTime;
     }
-
-    public function isExpired($resetExpire)
-    {
-        $expiryDate = new \DateTime($resetExpire . ' seconds ago');
-        return $this->getRequestTime() < $expiryDate;
-    }
 }


### PR DESCRIPTION
entities may only have methods for fields that exist in their database table. otherwise the method is called without parameter which leads to an error.
