### PR TITLE
updated the routes to work with mongodb user ids as well

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -36,7 +36,7 @@ return array(
                                 'action'     => 'reset',
                             ),
                             'constraints' => array(
-                                'userId'  => '[0-9]+',
+                                'userId'  => '[A-Fa-f0-9]+',
                                 'token' => '[A-F0-9]+',
                             ),
                         ),


### PR DESCRIPTION
An auto generated "primary key" of mongodb is a hexadecimal string, meaning the zfcuser' user id can use a-f chars as well.
