### PR TITLE
Fix: removed the fixed overriding for zfc-user/user/login view.

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -3,10 +3,7 @@ return array(
     'view_manager' => array(
         'template_path_stack' => array(
             'goalioforgotpassword' => __DIR__ . '/../view',
-        ),
-        'template_map' => array(
-            'zfc-user/user/login' => __DIR__ . '/../view/zfc-user/user/login.phtml',
-        ),
+        ),        
     ),
     'controllers' => array(
         'invokables' => array(


### PR DESCRIPTION
The problem was that configuration always fix the login rendering view to the goalio template, and this way broked the posibility you to use the standard zf2 overriding config process of views(https://github.com/ZF-Commons/ZfcUser/wiki/How-to-override-built-in-view-scripts).... for instance in my application i have a web app and a mobile app, both with a login page with differents template views, and with the current config just don't work
